### PR TITLE
Tickets/dm 35507

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,13 @@
 ##################
 Version History
 ##################
+.. _lsst.ts.phosim-2.0.6/
+
+-------------
+2.0.6
+-------------
+
+* Set detector center as the default star position for corner sensors simulation.
 
 .. _lsst.ts.phosim-2.0.5/
 

--- a/python/lsst/ts/phosim/CloseLoopTask.py
+++ b/python/lsst/ts/phosim/CloseLoopTask.py
@@ -29,7 +29,7 @@ import astropy.io.ascii
 
 import numpy as np
 
-from lsst.afw.cameraGeom import DetectorType
+from lsst.afw.cameraGeom import DetectorType, FIELD_ANGLE
 
 from lsst.daf import butler as dafButler
 
@@ -135,7 +135,14 @@ class CloseLoopTask(object):
         if instName in ("comcam", "lsstfam"):
             opdMetr.setWgtAndFieldXyOfGQ(instName)
         elif instName == "lsst":
-            fieldX, fieldY = opdMetr.getDefaultLsstWfsGQ()
+            fieldX, fieldY = list(), list()
+            camera = getCamera(instName)
+            for name in self.getSensorNameListOfFields(instName):
+                detector = camera.get(name)
+                xRad, yRad = detector.getCenter(FIELD_ANGLE)
+                xDeg, yDeg = np.rad2deg(xRad), np.rad2deg(yRad)
+                fieldY.append(xDeg)  # transpose for phoSim
+                fieldX.append(yDeg)
             opdMetr.setFieldXYinDeg(fieldX, fieldY)
         else:
             raise ValueError(f"This instrument name ({instName}) is not supported.")

--- a/tests/test_closeLoopTask.py
+++ b/tests/test_closeLoopTask.py
@@ -67,7 +67,7 @@ class TestCloseLoopTask(unittest.TestCase):
         self.closeLoopTask.configSkySim("lsst")
 
         skySim = self.closeLoopTask.getSkySim()
-        self.assertEqual(len(skySim.getStarId()), 4)
+        self.assertEqual(len(skySim.getStarId()), 8)
 
     def testConfigSkySimWithSkyFile(self):
 


### PR DESCRIPTION
Set default star position to detector center for corner sensors. Previously it was OPD positions, which is in-between corner sensors. 