### PR TITLE
Tickets/DM-36934: Update Jenkinsfile plantuml

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
         // Module name used in the pytest coverage analysis
         MODULE_NAME = "lsst.ts.phosim"
         // PlantUML url
-        PLANTUML_URL = "http://sourceforge.net/projects/plantuml/files/plantuml.jar"
+        PLANTUML_URL = "https://github.com/plantuml/plantuml/releases/download/v1.2022.12/plantuml.jar"
         // Authority to publish the document online
         user_ci = credentials('lsst-io')
         LTD_USERNAME = "${user_ci_USR}"

--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.phosim-2.1.0/
+
+-------------
+2.1.0
+-------------
+
+* Update Jenkinsfile to use github plantuml.
+
 .. _lsst.ts.phosim-2.0.9/
 
 -------------


### PR DESCRIPTION
Updated the plantuml link to use github one as sourceforge appears to be unstable, breaking `develop` builds https://tssw-ci.lsst.org/job/LSST_Telescope-and-Site/job/ts_phosim/job/develop/594/