### PR TITLE
Tickets/DM-37029: fix convertReferenceCatalog config

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,13 @@
 ##################
 Version History
 ##################
+.. _lsst.ts.phosim-2.2.2:
+
+-------------
+2.2.2
+-------------
+
+* Update config to run convertReferenceCatalog.
 
 .. _lsst.ts.phosim-2.2.1:
 

--- a/python/lsst/ts/phosim/CloseLoopTask.py
+++ b/python/lsst/ts/phosim/CloseLoopTask.py
@@ -1488,6 +1488,7 @@ tasks:
 config.dec_name='Decl'
 config.id_name='Id'
 config.mag_column_list=['g']
+config.dataset_config.ref_dataset_name='ref_cat'
 """
             )
 


### PR DESCRIPTION
Adding `ref_dataset_name ` to allow execution of `convertReferenceCatalog`