### PR TITLE
tickets/DM-37062: moved sqrt(2) inside rms calculation.

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,15 @@
 ##################
 Version History
 ##################
+
+.. _lsst.ts.phosim-2.2.4:
+
+-------------
+2.2.4
+-------------
+
+* Update documentation in ConvertZernikesToPsfWidth.py to account for factor of 1/sqrt(2).
+
 .. _lsst.ts.phosim-2.2.3:
 
 -------------

--- a/python/lsst/ts/phosim/utils/ConvertZernikesToPsfWidth.py
+++ b/python/lsst/ts/phosim/utils/ConvertZernikesToPsfWidth.py
@@ -66,24 +66,19 @@ def getPsfGradPerZernike(
         # Create the Zernike polynomial with these coefficients
         Z = galsim.zernike.Zernike(coefs, R_outer=R_outer, R_inner=R_inner)
 
-        # We can calculate the size of the PSF from the RSS of the gradient of
+        # We can calculate the size of the PSF from the RMS of the gradient of
         # the wavefront. The gradient of the wavefront perturbs photon paths.
-        # The RSS quantifies the size of the collective perturbation.
+        # The RMS quantifies the size of the collective perturbation.
         # If we expand the wavefront gradient in another series of Zernike
         # polynomials, we can exploit the orthonormality of the Zernikes to
-        # calculate the RSS from the Zernike coefficients.
-        rss_tilt = np.sqrt(np.sum(Z.gradX.coef**2 + Z.gradY.coef**2))
+        # calculate the RMS from the Zernike coefficients.
+        rms_tilt = np.sqrt(np.sum(Z.gradX.coef**2 + Z.gradY.coef**2) / 2)
 
         # Convert to arcsec per micron
-        rss_tilt = np.rad2deg(rss_tilt * 1e-6) * 3600
+        rms_tilt = np.rad2deg(rms_tilt * 1e-6) * 3600
 
         # Convert rms -> fwhm
-        fwhm_tilt = 2 * np.sqrt(2 * np.log(2)) * rss_tilt
-
-        # Multiply by factor of 1/sqrt(2)
-        # The origin of this factor is uncertain.
-        # It's value is determined empirically from Galsim simulation.
-        fwhm_tilt /= np.sqrt(2)
+        fwhm_tilt = 2 * np.sqrt(2 * np.log(2)) * rms_tilt
 
         # Save this conversion factor
         conversion_factors[i] = fwhm_tilt


### PR DESCRIPTION
The previous implementation of the zernike conversion had an empirical factor of 1/sqrt(2). Josh realized this was because there was supposed to be a division by 2 inside the square root for the rms calculation. I moved this factor inside the square root and updated the documentation to reflect this change.

This change is purely semantic -- it has no impact on any calculations.