### PR TITLE
Update default overscan correction to MEDIAN

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -5,6 +5,14 @@
 ##################
 Version History
 ##################
+.. _lsst.ts.phosim-2.2.3:
+
+-------------
+2.2.3
+-------------
+
+* Update default ISR overscan setting.
+
 .. _lsst.ts.phosim-2.2.2:
 
 -------------

--- a/policy/donutTemplateData/createPhosimDonutTemplateConfig.yaml
+++ b/policy/donutTemplateData/createPhosimDonutTemplateConfig.yaml
@@ -28,3 +28,4 @@ tasks:
       doApplyGains: True
       doFringe: False
       doOverscan: True
+      python: OverscanCorrectionTask.ConfigClass.fitType = 'MEDIAN'


### PR DESCRIPTION
This fixes the donut template test.