### PR TITLE
Tickets/DM-37130: update ISR settings

### DIFF
--- a/doc/versionHistory.rst
+++ b/doc/versionHistory.rst
@@ -6,6 +6,14 @@
 Version History
 ##################
 
+.. _lsst.ts.phosim-2.2.5:
+
+-------------
+2.2.5
+-------------
+
+* Update CloseLoopTask ISR setting.
+
 .. _lsst.ts.phosim-2.2.4:
 
 -------------

--- a/python/lsst/ts/phosim/CloseLoopTask.py
+++ b/python/lsst/ts/phosim/CloseLoopTask.py
@@ -1140,6 +1140,7 @@ tasks:
       doApplyGains: True
       doFringe: False
       doOverscan: True
+      python: OverscanCorrectionTask.ConfigClass.fitType = 'MEDIAN'
   generateDonutCatalogWcsTask:
     class: lsst.ts.wep.task.GenerateDonutCatalogWcsTask.GenerateDonutCatalogWcsTask
     # Here we specify the configurations for pointing that we added into the class


### PR DESCRIPTION
Update the CloseLoopTask ISR settings (previously in #77 they were updated in test file to fix test; this  introduces the same change to the main AOS loop so that the images created by phosim have a correct overscan correction applied). 